### PR TITLE
decodeUnsafe shouldn't throw

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,7 @@ function encode (payload) {
   ], payload.length + 4))
 }
 
-// Decode a base58-check encoded string to a buffer, no result if checksum is wrong
-function decodeUnsafe (string) {
-  var buffer = new Buffer(base58.decode(string))
-
+function decodeRaw (buffer) {
   var payload = buffer.slice(0, -4)
   var checksum = buffer.slice(-4)
   var newChecksum = sha256x2(payload)
@@ -35,8 +32,19 @@ function decodeUnsafe (string) {
   return payload
 }
 
+// Decode a base58-check encoded string to a buffer, no result if checksum is wrong
+function decodeUnsafe (string) {
+  var array = base58.decodeUnsafe(string)
+  if (!array) return
+
+  var buffer = new Buffer(array)
+  return decodeRaw(buffer)
+}
+
 function decode (string) {
-  var payload = decodeUnsafe(string)
+  var array = base58.decode(string)
+  var buffer = new Buffer(array)
+  var payload = decodeRaw(buffer)
   if (!payload) throw new Error('Invalid checksum')
   return payload
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bs58": "^2.0.1",
+    "bs58": "^3.1.0",
     "create-hash": "^1.1.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -4,19 +4,24 @@ var tape = require('tape')
 
 fixtures.valid.forEach(function (f) {
   tape('decodes ' + f.string, function (t) {
-    t.plan(1)
+    t.plan(2)
     var actual = bs58check.decode(f.string).toString('hex')
 
+    t.equal(actual, f.payload)
+
+    actual = bs58check.decodeUnsafe(f.string).toString('hex')
     t.equal(actual, f.payload)
   })
 })
 
 fixtures.invalid.forEach(function (f) {
   tape('decode throws on ' + f, function (t) {
-    t.plan(1)
+    t.plan(2)
     t.throws(function () {
       bs58check.decode(f)
     }, /Invalid checksum/)
+
+    t.equal(bs58check.decodeUnsafe(f), undefined)
   })
 })
 


### PR DESCRIPTION
Added tests,  bumped `bs58` dependency.

Waiting on publish from https://github.com/cryptocoinjs/bs58/pull/20, ping @jprichardson 