### PR TITLE
use safe-buffer

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var base58 = require('bs58')
+var Buffer = require('safe-buffer').Buffer
 
 module.exports = function (checksumFn) {
   // Encode a buffer as a base58-check encoded string


### PR DESCRIPTION
Its already a dependency,  its used in the tests... we missed it in `base.js` though.